### PR TITLE
chore: initially create storage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/
 textfiles.go
 __debug_bin
 storage/
+!storage/.gitkeep

--- a/storage.go
+++ b/storage.go
@@ -169,7 +169,10 @@ func initStorage() {
 		logger.Error(err)
 	}
 
-	sessionsstore, _ = sqlitestore.NewSqliteStoreFromConnection(db, "sessions", "/", 360000, sessionskey)
+	sessionsstore, err = sqlitestore.NewSqliteStoreFromConnection(db, "sessions", "/", 360000, sessionskey)
+	if err != nil {
+		logger.Fatalf("Could not init DB: %v", err)
+	}
 	sessionsstore.Options.Domain = Config.Domain
 	sessionsstore.Options.Secure = true
 	sessionsstore.Options.HttpOnly = false


### PR DESCRIPTION
otherwise, db could not be created with `unable to open database "storage/sessions.db": unable to open database file`